### PR TITLE
Crash fix.

### DIFF
--- a/SJAlertView/SJAlertView.m
+++ b/SJAlertView/SJAlertView.m
@@ -126,7 +126,7 @@ static NSString *const kFontName              = @"Helvetica";
     if (self.buttons && self.buttons.count > 0) {
         NSMutableArray<NSNumber *> *buttonWidths = [NSMutableArray<NSNumber *> array];
         for (NSValue *value in self.buttons) {
-            UIButton *button = (UIButton *)value;
+            UIButton *button = (UIButton *)value.nonretainedObjectValue;
             NSString *str = [button titleForState:UIControlStateNormal];
             CGFloat w = [str boundingRectWithSize:CGSizeMake(135, 0.0)
                                           options:NSStringDrawingUsesLineFragmentOrigin


### PR DESCRIPTION
Fixes a fatal issue when trying to present an alert.

`[NSConcreteValue titleForState:]: unrecognized selector sent to instance 0xXXXXXXX`